### PR TITLE
feat: support range-based-for

### DIFF
--- a/Matrix/TCL_Matrix.h
+++ b/Matrix/TCL_Matrix.h
@@ -2488,6 +2488,192 @@ namespace TCL_Matrix
             }
             of.close();
         }
+
+        
+        class const_row_vector_iterator
+        {
+        public:
+            class const_row_vector_reference
+            {
+            public:
+                using const_iterator = const double*;
+
+                const_iterator cbegin() const
+                {
+                    return ptr;
+                }
+
+                const_iterator cend() const
+                {
+                    return end_ptr;
+                }
+
+                const_iterator begin() const
+                {
+                    return this->cbegin();
+                }
+
+                const_iterator end() const
+                {
+                    return this->cend();
+                }
+
+                const_row_vector_reference(const const_row_vector_reference&) = default;
+                const_row_vector_reference& operator=(const const_row_vector_reference&) = default;
+                
+            protected:
+                const_row_vector_reference() = default;
+                const_row_vector_reference(double* ptr, double* end_ptr) : ptr(ptr), end_ptr(end_ptr) {}
+
+                double* ptr = nullptr;
+                double* end_ptr = nullptr;
+
+                friend class const_row_vector_iterator;
+            };
+
+            using value_type = const_row_vector_reference;
+
+            const_row_vector_iterator() = default;
+            const_row_vector_iterator(const const_row_vector_iterator&) = default;
+            const_row_vector_iterator& operator=(const const_row_vector_iterator&) = default;
+
+            explicit const_row_vector_iterator(double** ptr, int col) : ptr(ptr), col(col) {}
+
+            bool operator==(const const_row_vector_iterator& op) const
+            {
+                return this->ptr == op.ptr;
+            }
+
+            bool operator!=(const const_row_vector_iterator& op) const
+            {
+                return !(*this == op);
+            }
+            
+            value_type operator*() const
+            {
+                return const_row_vector_reference(*ptr, *ptr + col);
+            }
+
+            const_row_vector_iterator& operator++()
+            {
+                ++this->ptr;
+                return *this;
+            }
+
+            const_row_vector_iterator operator++(int)
+            {
+                auto org = *this;
+                this->operator++();
+                return org;
+            }
+
+        protected:
+            double** ptr = nullptr;
+            int col = 0;
+        };
+
+        class row_vector_iterator final : public const_row_vector_iterator
+        {
+        public:
+
+            class row_vector_reference final : public const_row_vector_reference
+            {
+            public:
+                using const_row_vector_reference::begin;
+                using const_row_vector_reference::end;
+                using const_row_vector_reference::cbegin;
+                using const_row_vector_reference::cend;
+                using const_row_vector_reference::const_iterator;
+                using iterator = double*;
+
+                row_vector_reference& operator=(const row_vector_reference& op)
+                {
+                    this->const_row_vector_reference::operator=(op);
+                    return *this;
+                }
+
+                row_vector_reference(const row_vector_reference&) = default;
+
+                iterator begin()
+                {
+                    return ptr;
+                }
+
+                iterator end()
+                {
+                    return end_ptr;
+                }
+
+            protected:
+                row_vector_reference() = default;
+                row_vector_reference(double* ptr, double* end_ptr) : const_row_vector_reference(ptr, end_ptr) {}
+                friend class row_vector_iterator;
+            };
+
+            using const_row_vector_iterator::operator==;
+            using const_row_vector_iterator::operator!=;
+            
+            using value_type = row_vector_reference;
+
+            row_vector_iterator() = default;
+            row_vector_iterator(const row_vector_iterator& op) = default;
+
+            row_vector_iterator& operator=(const row_vector_iterator& op)
+            {
+                this->const_row_vector_iterator::operator=(op);
+                return *this;
+            }
+
+            explicit row_vector_iterator(double** ptr, int col) : const_row_vector_iterator(ptr, col) {}
+
+            row_vector_reference operator*()
+            {
+                return row_vector_reference(*ptr, *ptr + col);
+            }
+
+            row_vector_iterator& operator++()
+            {
+                this->const_row_vector_iterator::operator++();
+                return *this;
+            }
+
+            row_vector_iterator& operator++(int)
+            {
+                auto origin = *this;
+                this->operator++();
+                return origin;
+            }
+        };
+
+        const_row_vector_iterator cbegin() const
+        {
+            return const_row_vector_iterator(this->matrix, this->col);
+        }
+
+        const_row_vector_iterator cend() const
+        {
+            return const_row_vector_iterator(this->matrix + this->row, this->col);
+        }
+
+        const_row_vector_iterator begin() const
+        {
+            return this->cbegin();
+        }
+
+        const_row_vector_iterator end() const
+        {
+            return this->cend();
+        }
+
+        row_vector_iterator begin()
+        {
+            return row_vector_iterator(this->matrix, this->col);
+        }
+
+        row_vector_iterator end()
+        {
+            return row_vector_iterator(this->matrix + this->row, this->col);
+        }
     };
 
     /// <summary>

--- a/Matrix/test.cpp
+++ b/Matrix/test.cpp
@@ -7,7 +7,7 @@ using namespace TCL_Matrix;
 /// <returns></returns>
 int main()
 {
-    /*//样例1：创建矩阵
+    //样例1：创建矩阵
     double a[8][8] =   //注：这是一个正交矩阵，下面会用这个正交矩阵生成一个矩阵来求特征值
     {
         {0.33333333,-0.66666667,0,0.666666667,0,0,0,0},
@@ -21,7 +21,31 @@ int main()
     };
     Matrix A((double*)a, 8, 8);  //创建一个8*8，以数组a为矩阵的对象
     A.Display(10); //显示A矩阵
+
+    // range-based-for
+    const Matrix& crA = A;
+    for (auto&& row_vec : crA)
+    {
+        for (auto&& elem : row_vec)
+        {
+            std::cout << std::setprecision(3) << std::setw(10) << elem << " ";
+        }
+        std::cout << '\n';
+    }
+    std::cout << std::endl;
+
+    Matrix& rA = A;
+    for (auto&& row_vec : rA)
+    {
+        for (auto&& elem : row_vec)
+        {
+            elem = 1.5;
+        }
+    }
+    rA.Display(10);
+
     std::cout << "=========================================================================================" << std::endl;
+    /*
 
     //样例2：矩阵转置
     Matrix A1 = Transpose(A); //创建A1矩阵，为A矩阵的转置


### PR DESCRIPTION
## range-based-for support

Now the `Matrix` supports range-based-for in C++11. For example: 
```c++
Matrix m;
for (auto&& row_vec : m)    // calls `begin()`
{
    for (auto&& elem : row_vec)
    {
        elem = 5;
    }
}

const Matrix& crm = m;
for (auto&& row_vec : crm)    // calls `begin() const`
{
    for (auto&& elem : row_vec)
    {
        std::cout << elem << ' ';
    }
    std::cout << '\n';
}
```

### Known bugs: 

+ `iterator` cannot be used like usual pointers  

  + **general**: Due to each rows of the matrix is wrapped by `(const_)row_vector_wrapper`, which is a temporary object returned when `decltype(Matrix::(c)begin)::operator*` is called instead of the true reference of the row vector, the return value of `Matrix::(c)begin` cannot call `operator->` like a usual pointer because dereference the pointer to a temporary object will cause an undefined behavior. 

  + **effect**: `m.begin()->begin()` (where `m` is of type `Matrix`) is forbidden. We must use `(*m.begin()).begin()` instead. 

